### PR TITLE
Enable version updates for github actions

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,12 @@
+# To get started with Dependabot version updates, you'll need to specify which
+# package ecosystems to update and where the package manifests are located.
+# Please see the documentation for all configuration options:
+# https://docs.github.com/github/administering-a-repository/configuration-options-for-dependency-updates
+
+version: 2
+updates:
+  # Maintain dependencies for GitHub Actions
+  - package-ecosystem: "github-actions"
+    directory: "/" # For GitHub Actions, set the directory to / to check for workflow files in .github/workflows.
+    schedule:
+      interval: "weekly"


### PR DESCRIPTION
This PR will enable  [Dependabot version updates for GitHub Actions](https://docs.github.com/en/code-security/dependabot/working-with-dependabot/keeping-your-actions-up-to-date-with-dependabot#example-dependabotyml-file-for-github-actions) in this reusable workflows repo


Reusable workflows enable a massive maintainability improvement for security hygiene of Actions workflows.  GitHub has [published guidance for security hardening when using 3rd party actions](https://docs.github.com/en/actions/security-guides/security-hardening-for-github-actions#using-third-party-actions) that recommends maintainers `Pin actions to a full length commit SHA`.    Without reusable workflows, each dependent repository would need a process to review and update commit SHA - it may require a massive amount of PRs across the org/enterprise when a new version is released. 

Reusable workflows enable you to have a centralized location to keep action versions up to date (latest version based `commit SHA`).  Further, the caller needs not worry about 3rd party versions as they simply refer to the tag of the reusable workflow via `/org/reusable-workflow-repo/xyz.yml@main`.  To enforce an audit process to review any updates to the reusable workflows you can restrict repo access and add [CODEOWNERS](https://docs.github.com/en/enterprise-cloud@latest/repositories/managing-your-repositorys-settings-and-features/customizing-your-repository/about-code-owners) file + [Require review from Code Owners ](https://docs.github.com/en/enterprise-cloud@latest/repositories/configuring-branches-and-merges-in-your-repository/defining-the-mergeability-of-pull-requests/about-protected-branches#require-pull-request-reviews-before-merging)branch protection rules.  During audit is recommended to: 

> Ensure that the action is handling the content of your repository and secrets as expected. For example, check that secrets are not sent to unintended hosts, or are not inadvertently logged. 

